### PR TITLE
cancel request context when signal is received

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,18 +109,18 @@ func main() {
 	var ticker *time.Ticker
 
 	// On ^C, or SIGTERM handle exit.
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, syscall.SIGTERM)
+	signals := make(chan os.Signal, 0)
+	signal.Notify(signals, os.Interrupt)
+	signal.Notify(signals, syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		for sig := range c {
+		for sig := range signals {
+			cancel()
 			ticker.Stop()
 			logrus.Infof("Received %s, exiting.", sig.String())
 			os.Exit(0)
 		}
 	}()
-
-	ctx := context.Background()
 
 	// Create the http client.
 	ts := oauth2.StaticTokenSource(


### PR DESCRIPTION
Cancels request context if signal is received. If the request take a while for whatever reason, this will allow a clean shutdown while that request is in progress.